### PR TITLE
Seed ScopeHouse Ops business roadmap foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# ScopeHouse-Ops
+# ScopeHouse Ops
+
+This repo is the operating layer for ScopeHouse.
+
+It holds the business, validation, launch, pricing, sales, content, and operating documents that sit beside product development.
+
+The app repo stays focused on shipping software.
+This repo stays focused on building the business around it.
+
+## Purpose
+
+ScopeHouse is a renovation operating system for homeowners and renovation professionals.
+
+This repo supports the non-code work needed to turn ScopeHouse into a durable software business:
+
+- positioning
+- validation
+- pricing
+- design partner pipeline
+- launch planning
+- sales materials
+- content strategy
+- operating metrics
+- business roadmap
+- issue backlog for business work
+
+## Working rules
+
+1. Keep documents short, specific, and current.
+2. Prefer decisions over open notes.
+3. Tie work to user pain, revenue potential, or launch readiness.
+4. Separate MVP, later, and not now clearly.
+5. Treat docs as working assets, not archives.
+
+## Repo structure
+
+```text
+README.md
+/docs
+  /90-day-business-roadmap.md
+  /operating-model.md
+  /milestones.md
+  /backlog
+    /business-roadmap-issues.md
+```
+
+## Current focus
+
+Current priority is to build the business foundation before MVP launch:
+
+- sharpen wedge and positioning
+- recruit design partners
+- validate willingness to pay
+- prepare founder-led onboarding
+- stand up launch and sales infrastructure
+- define the first operating cadence
+
+## Relationship to the app repo
+
+Use the app repo for:
+
+- product requirements
+- architecture and engineering docs
+- implementation issues
+- shipping roadmap
+- release work
+
+Use this repo for:
+
+- business roadmap
+- pricing and packaging
+- customer research
+- design partner management
+- launch planning
+- content engine
+- sales process
+- operating metrics

--- a/docs/90-day-business-roadmap.md
+++ b/docs/90-day-business-roadmap.md
@@ -1,0 +1,169 @@
+# ScopeHouse 90 Day Business Roadmap
+
+## Goal
+
+Build the commercial foundation for ScopeHouse before broad MVP launch.
+
+## Wedge
+
+Primary wedge:
+
+- homeowners planning medium to large renovations
+- solo GCs and renovation consultants who need stronger project control without heavy contractor ERP software
+
+Why this wedge:
+
+- pain is clear
+- projects are high stakes
+- value is visible fast
+- buyer language is concrete
+- product can expand into small firms later
+
+## Revenue model
+
+### Phase 1
+
+Use a hybrid of services and software.
+
+1. Founder-led setup and scope cleanup
+2. Paid quote comparison and renovation planning support
+3. Paid pilot accounts for pros
+
+### Phase 2
+
+Layer in subscriptions.
+
+- homeowner per-project plan
+- solo pro monthly plan
+- small team monthly plan
+
+## Pricing tests
+
+Initial price tests:
+
+- homeowner project plan, $79 to $149 per project
+- solo pro plan, $99 to $149 per month
+- small team plan, $249 to $399 per month
+- founder-led service offer, $300 to $1500 per engagement
+
+These are starting points for testing, not final pricing.
+
+## 90 day plan
+
+### Days 1 to 30, foundation
+
+Objective:
+Stand up the business layer.
+
+Deliverables:
+
+- positioning statement
+- homepage copy draft
+- waitlist form
+- interview script
+- design partner target list
+- pricing hypotheses
+- demo account and walkthrough script
+- metrics baseline
+- founder CRM
+
+Success gate:
+
+- 20 interviews scheduled or completed
+- 10 design partners identified
+- clear segment tags for every conversation
+
+### Days 31 to 60, validation and pipeline
+
+Objective:
+Turn interest into structured validation.
+
+Deliverables:
+
+- design partner outreach system
+- paid service offer
+- onboarding checklist
+- objection log
+- founder sales deck
+- sample exports for demos
+- content topics and publishing plan
+
+Success gate:
+
+- 8 active design partner conversations
+- 3 paid service engagements or paid pilots
+- clear willingness to pay signals by segment
+
+### Days 61 to 90, beta readiness
+
+Objective:
+Prepare to convert MVP into a disciplined private beta.
+
+Deliverables:
+
+- beta onboarding flow
+- support process
+- weekly business review cadence
+- retention and activation dashboard definitions
+- launch messaging
+- customer story capture process
+
+Success gate:
+
+- 5 active beta users
+- at least 3 users complete the core planning loop
+- at least 3 users export project summaries
+- at least 3 users pay in any form
+
+## Channels
+
+Start with channels that match founder-led selling.
+
+1. direct outreach to homeowners with active renovation plans
+2. direct outreach to solo GCs and renovation consultants
+3. founder content on renovation scope, quote comparison, and change control
+4. local and network-based referrals
+5. selective outreach to designers and design-build operators
+
+Avoid paid acquisition early.
+
+## Core metrics
+
+### Validation metrics
+
+- interviews completed
+- design partners recruited
+- paid pilots sold
+- service revenue closed
+
+### Product-connected business metrics
+
+- project creation to scope completion rate
+- export usage
+- first-week active rate
+- retention by segment
+- willingness to pay by segment
+
+### Sales metrics
+
+- outreach sent
+- reply rate
+- discovery calls booked
+- demos run
+- pilot conversion rate
+
+## Risks
+
+1. serving homeowners and pros too broadly at once
+2. weak first-session value
+3. pricing too low for service-heavy onboarding
+4. drifting toward generic contractor software
+5. too much planning without enough live user contact
+
+## Standing decisions
+
+1. Keep ScopeHouse below full contractor ERP.
+2. Keep AI in a support role.
+3. Sell before broad launch.
+4. Use services to learn and fund.
+5. Let design partners shape the first business motion.

--- a/docs/backlog/business-roadmap-issues.md
+++ b/docs/backlog/business-roadmap-issues.md
@@ -1,0 +1,377 @@
+# ScopeHouse Business Roadmap Issues
+
+Use these as the first issue batch for ScopeHouse-Ops.
+
+## 1. Title
+Create ScopeHouse positioning statement v1
+
+### Problem
+ScopeHouse has product direction, but the business-facing positioning is not yet locked for external use.
+
+### Goal
+Define a clear statement of who ScopeHouse serves, what problem it solves, and what makes it different.
+
+### Scope
+- write one-line positioning
+- write short paragraph version
+- define what ScopeHouse is not
+- define primary early wedge
+
+### Acceptance criteria
+- positioning statement exists in markdown
+- wedge is named clearly
+- exclusions are listed clearly
+
+### Notes or constraints
+Keep this tied to the first revenue motion.
+
+---
+
+## 2. Title
+Write homepage message draft
+
+### Problem
+There is no approved homepage copy for the first landing page.
+
+### Goal
+Create the first homepage message set for waitlist and early demos.
+
+### Scope
+- headline
+- subhead
+- value bullets
+- CTA copy
+- segment-specific proof points
+
+### Acceptance criteria
+- copy is ready for web use
+- message matches positioning doc
+
+### Notes or constraints
+Do not write generic contractor software copy.
+
+---
+
+## 3. Title
+Build customer interview script
+
+### Problem
+Validation calls will drift without a consistent script.
+
+### Goal
+Create a repeatable interview script for homeowners and pros.
+
+### Scope
+- opening questions
+- current workflow questions
+- pain questions
+- willingness to pay questions
+- closing questions
+
+### Acceptance criteria
+- script works for both main segments
+- prompts are short and practical
+
+### Notes or constraints
+Questions should uncover present pain, not hypothetical opinions.
+
+---
+
+## 4. Title
+Create design partner qualification rubric
+
+### Problem
+Not every interested person should become a design partner.
+
+### Goal
+Define who qualifies for early onboarding.
+
+### Scope
+- project complexity signals
+- urgency signals
+- collaboration signals
+- payment signals
+- exclusion criteria
+
+### Acceptance criteria
+- rubric can be used in outreach and calls
+- scoring or pass-fail logic is documented
+
+### Notes or constraints
+Bias toward users with real active renovation work.
+
+---
+
+## 5. Title
+Build design partner tracker
+
+### Problem
+Early partner outreach will become messy without a tracker.
+
+### Goal
+Create a simple tracker for partner status and next steps.
+
+### Scope
+- account name
+- segment
+- stage
+- last contact
+- next action
+- notes
+
+### Acceptance criteria
+- tracker fields are defined
+- status stages are documented
+
+### Notes or constraints
+Keep it simple enough for founder-led use.
+
+---
+
+## 6. Title
+Define initial pricing hypotheses
+
+### Problem
+There is no shared pricing document for tests.
+
+### Goal
+Document starting price ranges for homeowner, pro, and service offers.
+
+### Scope
+- per-project homeowner pricing
+- solo pro monthly pricing
+- small team monthly pricing
+- founder-led service pricing
+
+### Acceptance criteria
+- price ranges are documented
+- rationale is stated for each offer
+
+### Notes or constraints
+These are test prices, not final public prices.
+
+---
+
+## 7. Title
+Design founder-led service offer v1
+
+### Problem
+ScopeHouse needs a near-term revenue path before scaled SaaS.
+
+### Goal
+Package a service offer that uses the product workflow and solves real pain.
+
+### Scope
+- offer name
+- target buyer
+- deliverables
+- pricing range
+- delivery steps
+
+### Acceptance criteria
+- service offer is clear enough to sell manually
+- offer links to ScopeHouse workflow
+
+### Notes or constraints
+Service should teach the product, not distract from it.
+
+---
+
+## 8. Title
+Write discovery call script
+
+### Problem
+Founder sales calls need structure.
+
+### Goal
+Create a short discovery script for homeowner and pro leads.
+
+### Scope
+- opener
+- pain questions
+- workflow questions
+- fit questions
+- next-step close
+
+### Acceptance criteria
+- script is under one page
+- script supports note-taking and qualification
+
+### Notes or constraints
+Do not over-script. Keep space for live conversation.
+
+---
+
+## 9. Title
+Write demo script for ScopeHouse core loop
+
+### Problem
+Demos will be inconsistent without a defined path.
+
+### Goal
+Create a live demo flow that shows the core planning loop clearly.
+
+### Scope
+- create project
+- intake
+- scope draft
+- decision log or quote comparison
+- export story
+
+### Acceptance criteria
+- demo script fits a short live session
+- value moments are named clearly
+
+### Notes or constraints
+Keep the story tied to renovation control.
+
+---
+
+## 10. Title
+Create objection handling sheet
+
+### Problem
+Common objections will repeat across calls and pilots.
+
+### Goal
+Document likely objections and grounded responses.
+
+### Scope
+- price objection
+- trust objection
+- early product objection
+- workflow fit objection
+- segment mismatch objection
+
+### Acceptance criteria
+- objection sheet is concise
+- every response ties back to user pain or value
+
+### Notes or constraints
+No hype language.
+
+---
+
+## 11. Title
+Define weekly business metrics review
+
+### Problem
+The team needs a fixed scorecard for business learning.
+
+### Goal
+Document the weekly metrics and review cadence.
+
+### Scope
+- pipeline metrics
+- interview metrics
+- pilot metrics
+- revenue metrics
+- activation metrics
+
+### Acceptance criteria
+- metrics are clearly named
+- review cadence is documented
+
+### Notes or constraints
+Use metrics that drive decisions, not vanity.
+
+---
+
+## 12. Title
+Create content engine outline
+
+### Problem
+Content efforts will be random without editorial structure.
+
+### Goal
+Define a small content system that supports trust and pipeline.
+
+### Scope
+- content pillars
+- target readers
+- post formats
+- reuse plan
+- publishing cadence
+
+### Acceptance criteria
+- content themes are named
+- formats are defined clearly
+
+### Notes or constraints
+Focus on renovation planning pain, not broad home content.
+
+---
+
+## 13. Title
+Write first 10 content topics
+
+### Problem
+There is no starter list for founder content.
+
+### Goal
+Create the first batch of practical content topics.
+
+### Scope
+- quote comparison
+- scope clarity
+- budget drift
+- decision tracking
+- change order control
+- renovation records
+
+### Acceptance criteria
+- 10 topics are listed
+- each topic has a one-line angle
+
+### Notes or constraints
+Bias toward topics that can support sales calls.
+
+---
+
+## 14. Title
+Define beta onboarding checklist
+
+### Problem
+Early onboarding will become inconsistent without a checklist.
+
+### Goal
+Create a checklist for onboarding beta users by segment.
+
+### Scope
+- setup steps
+- data needed from user
+- first success moment
+- support expectations
+- follow-up checkpoints
+
+### Acceptance criteria
+- checklist is usable by one person
+- first session outcomes are defined
+
+### Notes or constraints
+Keep onboarding tight and repeatable.
+
+---
+
+## 15. Title
+Create launch readiness checklist
+
+### Problem
+There is no shared definition of launch readiness.
+
+### Goal
+Document what must be true before private beta and broader launch.
+
+### Scope
+- messaging readiness
+- onboarding readiness
+- support readiness
+- pricing readiness
+- metrics readiness
+
+### Acceptance criteria
+- checklist is complete and actionable
+- launch gates are explicit
+
+### Notes or constraints
+Separate private beta from broader launch.

--- a/docs/milestones.md
+++ b/docs/milestones.md
@@ -1,0 +1,106 @@
+# ScopeHouse Milestones
+
+## 1. Business foundation
+
+Goal:
+Set up the minimum business operating system.
+
+Work:
+
+- repo structure
+- roadmap
+- metrics definitions
+- interview system
+- pipeline setup
+- price test notes
+
+## 2. Positioning and wedge validation
+
+Goal:
+Decide who ScopeHouse serves first and why.
+
+Work:
+
+- positioning statement
+- homepage message
+- segment comparison
+- objection list and answers
+- wedge decision note
+
+## 3. Design partner pipeline
+
+Goal:
+Build a live pipeline of early users.
+
+Work:
+
+- target account list
+- outreach templates
+- qualification rubric
+- design partner tracker
+- onboarding checklist
+
+## 4. Pricing and packaging
+
+Goal:
+Test how ScopeHouse should charge different user types.
+
+Work:
+
+- price options
+- offer structure
+- pilot pricing
+- service package definitions
+- billing notes
+
+## 5. Sales and demo system
+
+Goal:
+Create a repeatable founder-led sales motion.
+
+Work:
+
+- discovery script
+- demo script
+- follow-up templates
+- proposal template
+- pilot close process
+
+## 6. Content engine
+
+Goal:
+Use content to build trust and pipeline.
+
+Work:
+
+- editorial themes
+- content calendar
+- article briefs
+- founder post templates
+- customer story format
+
+## 7. Beta launch readiness
+
+Goal:
+Prepare for private beta with live onboarding and support.
+
+Work:
+
+- beta criteria
+- onboarding flow
+- support workflow
+- feedback loop
+- launch message set
+
+## 8. Post-MVP business expansion
+
+Goal:
+Prepare the next layer once the first revenue motion works.
+
+Work:
+
+- referral loop
+- partner channel ideas
+- pro template strategy
+- small-firm expansion plan
+- future monetization options

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -1,0 +1,137 @@
+# ScopeHouse Operating Model
+
+## Purpose
+
+Create a simple operating cadence for founder-led validation, launch prep, and business execution.
+
+## Weekly cadence
+
+### 1. Pipeline review
+
+Review:
+
+- new leads
+- replies
+- calls booked
+- active design partners
+- deals at risk
+
+Output:
+
+- updated pipeline status
+- next actions by account
+
+### 2. Product signal review
+
+Review:
+
+- top friction points
+- most requested outcomes
+- objections to value or pricing
+- segment differences between homeowner and pro users
+
+Output:
+
+- top 3 product insights
+- top 3 business insights
+- issues to create in app repo or ops repo
+
+### 3. Metrics review
+
+Track:
+
+- interviews completed
+- demos run
+- pilots sold
+- service revenue
+- active beta users
+- activation rate
+- exports created
+
+Output:
+
+- one-page weekly summary
+
+### 4. Content and outreach review
+
+Review:
+
+- content published
+- distribution done
+- response quality
+- next 2 pieces to ship
+
+Output:
+
+- weekly publishing list
+- weekly outreach list
+
+## Core operating documents
+
+This repo should eventually include:
+
+- positioning
+- pricing
+- interview notes
+- design partner tracker
+- sales playbook
+- launch plan
+- metrics dashboard definitions
+- content engine
+- decision log
+
+## Decision rules
+
+1. If a request supports revenue or validation, prioritize it.
+2. If a feature request expands scope without clear demand, defer it.
+3. If one user segment shows stronger payment and retention, bias toward that segment.
+4. If onboarding requires heavy founder work, charge for it.
+5. If docs go stale, update or remove them.
+
+## Design partner process
+
+### Stage 1, identify
+
+Target users with active renovation complexity.
+
+Signals:
+
+- multiple rooms or phases
+- meaningful budget pressure
+- quote comparison pain
+- scattered project records
+- need to communicate with others
+
+### Stage 2, qualify
+
+Confirm:
+
+- active project or project starting soon
+- clear pain around scope, pricing, or change tracking
+- willingness to test early software or paid planning help
+
+### Stage 3, onboard
+
+Walk users through:
+
+- project setup
+- intake
+- scope draft
+- export or quote comparison path
+
+### Stage 4, capture learning
+
+After each session log:
+
+- what they were trying to do
+- where they got stuck
+- what felt useful
+- what they would pay for
+- whether they would return
+
+## Repo discipline
+
+- keep docs in markdown
+- use dated decision logs when direction changes
+- create GitHub issues from repeated pain, not one-off comments
+- update roadmap after each major validation cycle


### PR DESCRIPTION
## Summary
This PR seeds the ScopeHouse-Ops repo with the first business operating documents and a starter backlog.

## What is included
- expanded repo README
- 90 day business roadmap
- operating model and weekly cadence
- milestone structure for business work
- first batch of business issues in GitHub-ready format

## Why
The app roadmap is moving in the product repo. This PR gives ScopeHouse a separate operating layer for business design, validation, pricing, sales, content, and launch planning.

## Notes
This is intentionally narrow. It creates the foundation without overbuilding the ops repo.

## Follow-up work
- convert backlog items into live GitHub issues
- add positioning doc
- add pricing doc
- add design partner tracker
- add sales playbook